### PR TITLE
dynamically update the pit temperature

### DIFF
--- a/custom_components/wlanthermo/sensor.py
+++ b/custom_components/wlanthermo/sensor.py
@@ -1155,9 +1155,8 @@ class WlanthermoPitmasterTemperatureSensor(CoordinatorEntity, SensorEntity):
     """
     def __init__(self, coordinator, pitmaster, device_name):
         super().__init__(coordinator)
-        # store pitmaster id (not the channel number) so we always resolve the current channel on each update
-        self._pitmaster_id = pitmaster.id
         self._attr_name = f"Pitmaster {pitmaster.id} Temperature"
+        self._pitmaster_channel = pitmaster.channel 
         self._attr_unique_id = f"{device_name}_pitmaster_{pitmaster.id}_temperature"
         self.entity_id = f"sensor.{device_name}_pitmaster_{pitmaster.id}_temperature"
         self._attr_icon = "mdi:thermometer"
@@ -1166,10 +1165,6 @@ class WlanthermoPitmasterTemperatureSensor(CoordinatorEntity, SensorEntity):
     def _get_channel(self):
         """
         Helper to get the channel object associated with the pitmaster.
-        Resolve the current channel object associated with this pitmaster.
-         - First find the current pitmaster object from coordinator.data.pitmasters by id
-         - Then use its channel number to find the matching channel in coordinator.data.channels
-        This way the mapping is up-to-date after each GET /data refresh.
         """
         
         # get latest pitmasters from coordinator data
@@ -1193,7 +1188,6 @@ class WlanthermoPitmasterTemperatureSensor(CoordinatorEntity, SensorEntity):
         """
         Return device info for Home Assistant device registry.
         """
-        # Return device info for Home Assistant device registry.
         entry_id = self.coordinator.config_entry.entry_id if hasattr(self.coordinator, 'config_entry') else None
         hass = getattr(self.coordinator, 'hass', None)
         if hass and entry_id:


### PR DESCRIPTION
The pit channel was only updated when the entity was created. With this commit, a change of the pit master channel results in a change in the appropriate pitmaster temperature to the now selected channel.

Checked only on WLANThermo mini-V3 with a single Pitmaster.
Please double check the code changes as I'm not really into python and got the changes only using Github Copilot.


In the picture one can see the jumps of the pit temperature from CH1 to CH 2 to CH3 between 00:25 and 00:27.
<img width="1253" height="544" alt="grafik" src="https://github.com/user-attachments/assets/b96c2492-8161-4932-b636-227b48a1ab2a" />
